### PR TITLE
Aggiunta compatibilità con regexp

### DIFF
--- a/dist/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo.d.ts
+++ b/dist/FatturaElettronicaBody/DatiBeniServizi/DatiRiepilogo.d.ts
@@ -14,9 +14,9 @@ export interface DatiRiepilogo {
      * Questo valore rappresenta: base imponibile per le operazioni soggette ad IVA; importo, per le operazioni che non
      * rientrano tra quelle imponibili.
      */
-    ImponibileImporto: number;
+    ImponibileImporto: number | string;
     /**Imposta risultante dall'applicazione dell'aliquota IVA all'imponibile. */
-    Imposta: number;
+    Imposta: number | string;
     /**Eseigibilità IVA (immediata ai sensi Art. 6 comma 5 del DPR 633 1972, oppure differita). */
     EsigibilitaIVA?: EsigibilitaIVA;
     /**Norma di riferimento (obbligatoria nei casi in cui Natura è valorizzato). */

--- a/dist/FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee.d.ts
+++ b/dist/FatturaElettronicaBody/DatiBeniServizi/DettaglioLinee.d.ts
@@ -17,7 +17,7 @@ export interface DettaglioLinee {
      */
     Descrizione: string;
     /**Numero di unità cedute / prestate. */
-    Quantita?: number | null;
+    Quantita?: number | null | string;
     /**Unità di misura riferita alla quantità. */
     UnitaMisura?: string;
     /**Data iniziale del periodo di riferimento cui si riferisce l'eventuale servizio prestato. */
@@ -25,16 +25,16 @@ export interface DettaglioLinee {
     /**Data finale del periodo di riferimento cui si riferisce l'eventuale servizio prestato. */
     DataFinePeriodo?: Date | string | null;
     /**Prezzo unitario del bene/servizio; nel caso di beni ceduti a titolo di sconto, premio o abbuono, l'importo indicato rappresenta il "valore normale". */
-    PrezzoUnitario: number;
+    PrezzoUnitario: number | string;
     /**
      * Eventuale sconto o maggiorazione applicati (la molteciplità N del blocco consente di gestire la presenza di più sconti o
      * maggiorazioni a "cascata").
      */
     ScontoMaggiorazione?: ScontoMaggiorazione[];
     /**Importo totale del bene/servizio (che tiene conto di eventuali sconti/maggiorazioni) IVA esclusa. */
-    PrezzoTotale: number;
+    PrezzoTotale: number | string;
     /**Aliquota (%) IVA applicata al bene/servizio. */
-    AliquotaIVA: number;
+    AliquotaIVA: number | string;
     /**Da valorizzare solo in caso di cessione/prestazione soggetta a ritenuta di acconto. */
     Ritenuta?: string;
     /**Natura dell'operazione se non rientra tra quelle imponibili (il campo Aliquota IVA deve essere valorizzato a zero). */


### PR DESCRIPTION
Alcune API di terze parti richiedono un formato numerico che presenti due decimali dopo il punto, anche per campi quali Quantità e Imposta.
